### PR TITLE
Allow Lazarus versions to fall through in switch-case

### DIFF
--- a/src/Lazarus.ts
+++ b/src/Lazarus.ts
@@ -306,152 +306,32 @@ export class Lazarus{
                 await this._downloadLazarus();
                 break;
             case '2.2.6':
-                await this._downloadLazarus();
-                break;
             case '2.2.4':
-                await this._downloadLazarus();
-                break;
             case '2.2.2':
-                await this._downloadLazarus();
-                break;
             case '2.2.0':
-                await this._downloadLazarus();
-                break;
             case '2.0.12':
-                await this._downloadLazarus();
-                break;
             case '2.0.10':
-                await this._downloadLazarus();
-                break;
             case '2.0.8':
                 await this._downloadLazarus();
                 break;
             case '2.0.6':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '2.0.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '2.0.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '2.0.0':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.8.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.8.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.8.0':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.6.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.6.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.6':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.4.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.4.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.2.6':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.2.4':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.2.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.2':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.0.14':
-                if (this._Platform == 'darwin'){
-                    throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');
-                } else {
-                    await this._downloadLazarus();
-                }
-                break;
             case '1.0.12':
                 if (this._Platform == 'darwin'){
                     throw new Error('GitHub runners do not support Lazarus below 2.0.8 on macos');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noFallthroughCasesInSwitch": false,      /* Ignore switch cases that omit the 'break' statement. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
   "exclude": ["__tests__", "lib", "node_modules"]


### PR DESCRIPTION
The toolchain installation logic can treat whole ranges of Lazarus versions as a *single* case instead of copy-pasting the same code under each individual case.

This makes the code easier to read and update; new Lazarus versions will only require a single added line when the installation steps don't require changes.